### PR TITLE
Program-specific intro course selection and Montserrat font

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,9 @@
 
   <head>
     <meta charset="UTF-8">
-    <title id="pageTitle">Berechnung des Weiterbildungsfortschritts</title>
+    <title id="pageTitle"></title>
+
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;700&display=swap" rel="stylesheet">
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
@@ -38,7 +40,7 @@
 
     <style>
       body {
-        font-family: sans-serif;
+        font-family: Montserrat,system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif;
         padding: 20px;
         max-width: 900px;
         margin: auto;
@@ -54,7 +56,7 @@
         border-radius: 32px;
         box-shadow: 0 4px 28px rgba(60,40,90,0.10);
         color: #352682;
-        font-family: sans-serif;
+        font-family: Montserrat,system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif;
       }
     
 
@@ -200,6 +202,12 @@
         text-align: left;
       }
 
+      .checkbox-group input[type="checkbox"] {
+        /* Prevent stretched checkboxes */
+        flex-grow: 0;
+        width: auto;
+      }
+
       .remove-period-btn {
         position: absolute;
         top: -18px;  
@@ -308,8 +316,8 @@
 
 
     <div id="headerContainer">
-      <h1 id="headerTitle">Berechnung des Weiterbildungsfortschritts</h1>
-      <h2 id="headerSubtitle" style="margin-top:-10px;">Psychiatrie und Psychotherapie bei Erwachsenen</h2>
+      <h1 id="headerTitle"></h1>
+      <h2 id="headerSubtitle" style="margin-top:-10px;"></h2>
     </div>
 
     <p id="disclaimer" style="text-align:center; font-size:0.9em; color:#666; max-width: 700px; margin: 10px auto 20px;"></p>
@@ -325,7 +333,7 @@
     <br>
 
     <div id="DomcambioCentro" class="section" style="display:none;">
-      <label for="gerntoPsy"><span id="labelGerontoPsy"></span>
+      <label for="gerontoPsy"><span id="labelGerontoPsy"></span>
         <select id="gerontoPsy">
           <option value="" disabled selected hidden></option>
           <option value="yes"></option>
@@ -347,7 +355,7 @@
     <h2 id="creditsTitle"></h2>
 
     <div class="centered-button">
-      <button id="addCreditSectionBtn">➕ Aggiungi crediti</button>
+      <button id="addCreditSectionBtn"></button>
     </div>
 
     <div id="creditSectionTeorici" class="section"style="display:none; position:relative;">
@@ -356,8 +364,17 @@
       <input type="number" id="creditiTeorici" min="0" max="500" placeholder="0">
       <span class="input-error" style="display:none;color:#dc3545;font-size:0.98em;margin-top:2px"></span>
       <div class="small-title" id="introTitle"></div>
-      <div class="checkbox-group">
-        <label><input type="checkbox" id="corso2024"><span id="labelCorso2024"></span></label>
+      <label id="introProgramLabel" for="introProgram"></label>
+      <select id="introProgram">
+        <option value=""></option>
+        <option value="2024"></option>
+        <option value="2009"></option>
+      </select>
+      <div id="intro2024Fields" style="display:none; margin-top:8px;">
+        <label for="creditiCorso2024" id="labelCorso2024"></label>
+        <input type="number" id="creditiCorso2024" min="1" max="50" placeholder="0">
+      </div>
+      <div id="intro2009Fields" class="checkbox-group" style="display:none; margin-top:8px;">
         <label><input type="checkbox" id="corsoCog"><span id="labelCorsoCog"></span></label>
         <label><input type="checkbox" id="corsoPsy"><span id="labelCorsoPsy"></span></label>
         <label><input type="checkbox" id="corsoSis"><span id="labelCorsoSis"></span></label>
@@ -388,7 +405,7 @@
     <h2 id="supervisionTitle"></h2>
 
     <div class="centered-button">
-      <button id="addSupervisionSectionBtn">➕ Aggiungi supervisioni</button>
+      <button id="addSupervisionSectionBtn"></button>
     </div>
 
     <div id="supervisionSection" class="section" style="display:none; position:relative;">
@@ -433,7 +450,7 @@
       <button id="calcBtn" style="display:none"></button>
     </div>
 
-    <button id="pdfButton" style="display:none; margin-bottom: 20px;">📄 Download PDF</button>
+    <button id="pdfButton" style="display:none; margin-bottom: 20px;"></button>
 
     <h2 id="resultHeader" style="display:none"></h2>
 
@@ -446,7 +463,7 @@
 
     <div id="supervisionOutput"></div>
 
-    <button id="clearButton">🗑️ Clear All</button>
+    <button id="clearButton"></button>
 
     <script>
       document.addEventListener('DOMContentLoaded', () => {
@@ -458,6 +475,10 @@
           headerSubtitle:'Psychiatrie und Psychotherapie bei Erwachsenen',
           disclaimer: 'Dieses Tool wird kostenlos angeboten von der Schweizerischen Vereinigung der Assistenzärztinnen und -ärzte in Psychiatrie (SVPA-ASMAP-ASAP). Das Tool basiert auf der Interpretation der Weiterbildungsprogramme des ISFM-FMH. Die Vereinigung und ihre Mitglieder übernehmen keine Verantwortung bei allfälligen Rechenfehlern. Es wird empfohlen, sich stets auf die offiziellen ISFM-FMH-Dokumente zu beziehen.',
           addPeriod:'➕ Periode hinzufügen',
+          addCredits:'➕ Credits hinzufügen',
+          addSupervisions:'➕ Supervisionen hinzufügen',
+          downloadPdf:'📄 PDF herunterladen',
+          clearAll:'🗑️ Alles löschen',
           questionGerontoPsy: 'Min. 6 Monate Gerontopsychiatrie?',
           optNoG:'Nein',
           optSiG:'Ja',
@@ -466,10 +487,13 @@
           optSi:'Ja',
           labelTeorici:'Theoretische Credits',
           introTitle:'Einführung in Modelle',
-          labelCorso2024:'Kurs 2024',
-          labelCorsoCog:'Kognitives Seminar',
-          labelCorsoPsy:'Psychodynamischer Kurs',
-          labelCorsoSis:'Systemischer Workshop',
+          introProgramQuestion:'Nach welchem Programm streben Sie den Facharzttitel an?',
+          optProgram2024:'Programm 2024',
+          optProgram2009:'Programm 2009',
+          labelCorso2024:'Einführungskurs Psychotherapie 2024',
+          intro2009Cog:'Kognitiv-Verhaltenstherapie',
+          intro2009Psy:'Psychodynamisch/Psychoanalytisch',
+          intro2009Sis:'Systemisch',
           labelPsy:'Psychiatrie-Credits',
           labelCong:'Kongress-Credits',
           labelSSPP:'Teilnahme an SSPP',
@@ -503,15 +527,28 @@
           catBAmb: 'B Ambulant allgemein',
           catCOsp: 'C Stationär allgemein',
           catCAmb: 'C Ambulant allgemein',
-          catFormApprof: 'Beliebige vertiefte Weiterbildungskategorie',
+          catGerOsp: 'Gerontopsychiatrie stationär',
+          catGerAmb: 'Gerontopsychiatrie ambulant',
+          catDipOsp: 'Abhängigkeiten stationär',
+          catDipAmb: 'Abhängigkeiten ambulant',
+          catForOsp: 'Forensische Psychiatrie stationär',
+          catForAmb: 'Forensische Psychiatrie ambulant',
+          catLiaOsp: 'Konsiliar/Liaison stationär',
+          catLiaAmb: 'Konsiliar/Liaison ambulant',
+          catOtherOsp: 'Andere stationäre Kategorien',
+          catOtherAmb: 'Andere ambulante Kategorien',
           mesiPlaceholder: 'Anzahl Monate eingeben',
           pensumPlaceholder: 'Pensum in % eingeben',
           workTitle: "Arbeitstätigkeit",
           creditsTitle: "Ausbildungscredits",
-          supervisionTitle: "Supervisionen",
           validMonths: "{v} / 72 gültige Monate",
           comments: "Kommentare",
           formErrors: "Fehler im Formular:",
+          removePeriod:'Zeitraum entfernen',
+          extraLabel:'Extra',
+          missingMonths:'Fehlende Monate',
+          periodsNoMissing:'✅ Keine Lücken in den eingegebenen Zeiträumen.',
+          creditsNoMissing:'✅ Keine Lücken in den eingegebenen Credits.',
           gerontoComment: "Die Min. 6 obligatorischen Monate in der Gerontopsychiatrie fehlen noch.",
           cambioCentroComment: "Wechsel der Weiterbildungsstätte gemäss Art. 2.1.2 erforderlich.",
           missingOspA: "Es fehlen {n} Monate in Kategorie A stationär (mindestens 12)",
@@ -535,10 +572,9 @@
           creditiMissingPsy: n => `Es fehlen noch  <b>${n}</b> Credits für psychotherapeutische Weiterbildung i.e.S.`,
           creditiMissingCong: n => `Es fehlen noch  <b>${n}</b> Credits für Kongresse, Workshops und Kurse`,
           creditiMissingIntro: "Du musst noch die Einführungskurse in Psychotherapie besuchen (in den 240 Basis-Credits enthalten)",
-          labelCorsoCog: 'Kognitiv-Verhaltenstherapie',
-          labelCorsoPsy: 'Psychodynamisch/Psychoanalytisch',
-          labelCorsoSis: 'Systemisch',
           creditiMissingIntroSome: mancanti => `Du musst noch die folgende Einführungskurse in Psychotherapie besuchen: <b>${mancanti.join(', ')}</b> gemäss Weiterbildungsprogramm 2009 oder den neuen 40-Credit-Kurs gemäss Weiterbildungsprogramm 2024`,
+          creditiMissingIntro2024: n => `Es fehlen noch <b>${n}</b> Credits im Einführungskurs Psychotherapie (Programm 2024).`,
+          creditiMissingProgram: "Du musst die Frage zum Programm beantworten.",
           creditiMissingSSPP: "Du hast die Frage zur Teilnahme am SGPP-Kongress nicht beantwortet",
           creditiMissingSSPPNo: "Du musst die vollständige Teilnahme am jährlichen SSPP-Kongress nachweisen",
           supervisionTitle: "Erforderliche Supervisionen",
@@ -566,6 +602,10 @@
           headerSubtitle:'Psychiatrie et psychothérapie des adultes',
           disclaimer: 'Cet outil est proposé gratuitement par l\'Association Suisse des Assistant·e·s en Psychiatrie (SVPA-ASMAP-ASAP). L\'outil est basé sur l\'interprétation des programmes de formation de l\'ISFM-FMH. L\'association et ses membres déclinent toute responsabilité en cas d\'erreurs de calcul. Il est recommandé de toujours se référer aux documents officiels de l\'ISFM-FMH.',
           addPeriod:'➕ Ajouter une période',
+          addCredits:'➕ Ajouter des crédits',
+          addSupervisions:'➕ Ajouter des supervisions',
+          downloadPdf:'📄 Télécharger le PDF',
+          clearAll:'🗑️ Tout effacer',
           questionGerontoPsy: 'Min. 6 mois de géronto-psychiatrie ?',
           optNoG:'Non',
           optSiG:'Oui',
@@ -574,10 +614,13 @@
           optSi:'Oui',
           labelTeorici:'Crédits théoriques',
           introTitle:'Introduction modèles',
-          labelCorso2024:'Cours 2024',
-          labelCorsoCog:'Séminaire cognitif',
-          labelCorsoPsy:'Cours psychodynamique',
-          labelCorsoSis:'Atelier systémique',
+          introProgramQuestion:'Selon quel programme poursuivez-vous le titre de spécialiste ?',
+          optProgram2024:'Programme 2024',
+          optProgram2009:'Programme 2009',
+          labelCorso2024:'Cours d’introduction à la psychothérapie 2024',
+          intro2009Cog:'Cognitivo-comportementale',
+          intro2009Psy:'Psychodynamique/psychanalytique',
+          intro2009Sis:'Systémique',
           labelPsy:'Crédits psychiatrie',
           labelCong:'Crédits congrès',
           labelSSPP:'Participation SSPP',
@@ -612,15 +655,28 @@
           catBAmb: 'B ambulatoire général',
           catCOsp: 'C hospitalier général',
           catCAmb: 'C ambulatoire général',
-          catFormApprof: 'Toute catégorie formation approfondie',
+          catGerOsp: 'Gérontopsychiatrie hospitalier',
+          catGerAmb: 'Gérontopsychiatrie ambulatoire',
+          catDipOsp: 'Dépendances hospitalier',
+          catDipAmb: 'Dépendances ambulatoire',
+          catForOsp: 'Psychiatrie forensique hospitalier',
+          catForAmb: 'Psychiatrie forensique ambulatoire',
+          catLiaOsp: 'Consultation et liaison hospitalier',
+          catLiaAmb: 'Consultation et liaison ambulatoire',
+          catOtherOsp: 'Autres catégories hospitalières',
+          catOtherAmb: 'Autres catégories ambulatoires',
           mesiPlaceholder: 'Entrer nombre de mois',
           pensumPlaceholder: 'Entrer le pensum en %',
           workTitle: "Activité professionnelle",
           creditsTitle: "Crédits de formation",
-          supervisionTitle: "Supervisions",
           validMonths: "{v} / 72 mois valides",
           comments: "Commentaires",
           formErrors: "Erreurs dans le formulaire :",
+          removePeriod:'Supprimer la période',
+          extraLabel:'Extra',
+          missingMonths:'Mois manquants',
+          periodsNoMissing:'✅ Aucune lacune dans les périodes saisies.',
+          creditsNoMissing:'✅ Aucune lacune dans les crédits saisis.',
           gerontoComment: "Les 6 mois obligatoires en géronto-psychiatrie manquent encore.",
           cambioCentroComment: "Changement de centre de formation selon l’art. 2.1.2 requis.",
           missingOspA: "Il manque {n} mois en hospitalier catégorie A (minimum 12)",
@@ -644,10 +700,9 @@
           creditiMissingPsy: n => `Il vous manque encore <b>${n}</b> crédits de formation en psychothérapie.`,
           creditiMissingCong: n => `Il vous manque encore <b>${n}</b> crédits de congrès, ateliers et cours.`,
           creditiMissingIntro: "Vous devez encore suivre les cours d’introduction à la psychothérapie (inclus dans les 240 crédits de base).",
-          labelCorsoCog: 'Cognitivo-comportementale',
-          labelCorsoPsy: 'Psychodynamique/psychanalytique',
-          labelCorsoSis: 'Systémique',
           creditiMissingIntroSome: mancanti => `Vous devez encore suivre les cours d’introduction à la psychothérapie suivants : <b>${mancanti.join(', ')}</b> selon le programme 2009 ou bien le nouveau cours complet de 40 crédits du programme 2024.`,
+          creditiMissingIntro2024: n => `Il vous manque encore <b>${n}</b> crédits dans le cours d’introduction à la psychothérapie (programme 2024).`,
+          creditiMissingProgram: "Vous devez répondre à la question sur le programme.",
           creditiMissingSSPP: "Vous devez répondre à la question sur la participation complète au congrès annuel de la SSPP.",
           creditiMissingSSPPNo: "La participation complète obligatoire au congrès annuel de la SSPP n’a pas encore été effectuée.",
           supervisionTitle: "Supervisions requises",
@@ -675,6 +730,10 @@
           headerSubtitle:'Psichiatria e Psicoterapia degli Adulti',
           disclaimer: 'Questo Tool è gratuitamente offerto dalla Associazione Svizzera degli Assistenti in Psichiatria (SVPA-ASMAP-ASAP). Il Tool è basato sull\'interpretazione dei programmi di formazione ISFM-FMH. L’associazione e i suoi membri non si ritengono responsabili in caso di errori di conteggio. Si raccomanda di fare sempre riferimento ai documenti ufficiali ISFM-FMH.',
           addPeriod:'➕ Aggiungi periodo',
+          addCredits:'➕ Aggiungi crediti',
+          addSupervisions:'➕ Aggiungi supervisioni',
+          downloadPdf:'📄 Scarica PDF',
+          clearAll:'🗑️ Pulisci tutto',
           questionGerontoPsy: 'Min. 6 mesi di gerontopsichiatria?',
           questionCambioCentro:'Art. 2.1.2: Durante la formazione hai cambiato centro?',
           optNoG:'No',
@@ -683,10 +742,13 @@
           optSi:'Sì',
           labelTeorici:'Crediti teorici',
           introTitle:'Introduzione modelli psicoterapeutici',
-          labelCorso2024:'Corso 2024',
-          labelCorsoCog:'Seminario cognitivo',
-          labelCorsoPsy:'Corso psicodinamico',
-          labelCorsoSis:'Workshop sistemico',
+          introProgramQuestion:'Secondo quale programma stai perseguendo il titolo di specialista?',
+          optProgram2024:'Programma 2024',
+          optProgram2009:'Programma 2009',
+          labelCorso2024:'Corso introduttivo alla psicoterapia 2024',
+          intro2009Cog:'Cognitivo-comportamentale',
+          intro2009Psy:'Psicodinamica/psicoanalitica',
+          intro2009Sis:'Sistemica',
           labelPsy:'Crediti Psichiatria',
           labelCong:'Crediti Congresso',
           labelSSPP:'Partecipazione SSPP',
@@ -719,15 +781,28 @@
           catBAmb: 'B ambulatoriale generale',
           catCOsp: 'C ospedaliero generale',
           catCAmb: 'C ambulatoriale generale',
-          catFormApprof: 'Qualsiasi categoria di Formazione Approfondita',
+          catGerOsp: 'Gerontopsichiatria ospedaliera',
+          catGerAmb: 'Gerontopsichiatria ambulatoriale',
+          catDipOsp: 'Dipendenze ospedaliera',
+          catDipAmb: 'Dipendenze ambulatoriale',
+          catForOsp: 'Forense ospedaliera',
+          catForAmb: 'Forense ambulatoriale',
+          catLiaOsp: 'Consiliare e Liaison ospedaliera',
+          catLiaAmb: 'Consiliare e Liaison ambulatoriale',
+          catOtherOsp: 'Altre categorie ospedaliere',
+          catOtherAmb: 'Altre categorie ambulatoriali',
           mesiPlaceholder: 'Inserisci numero di mesi totali',
           pensumPlaceholder: 'Inserisci il pensum in %',
           workTitle: "Attività lavorativa",
           creditsTitle: "Crediti di Formazione",
-          supervisionTitle: "Supervisioni",
           validMonths: "{v} / 72 mesi validi",
           comments: "Commento",
           formErrors: "Errori nel form:",
+          removePeriod:'Rimuovi periodo',
+          extraLabel:'Extra',
+          missingMonths:'Mesi mancanti',
+          periodsNoMissing:'✅ Non ci sono mancanze nei periodi inseriti.',
+          creditsNoMissing:'✅ Non ci sono mancanze nei crediti inseriti.',
           gerontoComment: "Mancano ancora i min. 6 mesi obbligatori in gerontopsichiatria.",
           cambioCentroComment: "È necessario il cambio del centro di formazione secondo l’Art. 2.1.2.",
           missingOspA: "Mancano {n} mesi in Ospedaliero categoria A (minimo 12)",
@@ -751,10 +826,9 @@
           creditiMissingPsy: n => `Ti mancano ancora <b>${n}</b> crediti di formazione psicoterapeutica.`,
           creditiMissingCong: n => `Ti mancano ancora <b>${n}</b> crediti di congressi, workshop e corsi.`,
           creditiMissingIntro: "Devi ancora frequentare i corsi introduttivi alla psicoterapia (inclusi nei 240 crediti di base).",
-          labelCorsoCog: 'cognitivo-comportamentale',
-          labelCorsoPsy: 'psicodinamica/psicoanalitica',
-          labelCorsoSis: 'sistemica',
           creditiMissingIntroSome: mancanti => `Devi ancora frequentare i seguenti corsi di introduzione alla psicoterapia: <b>${mancanti.join(', ')}</b> secondo programma 2009 oppure il nuovo corso completo da 40 crediti secondo programma 2024.`,
+          creditiMissingIntro2024: n => `Ti mancano ancora <b>${n}</b> crediti nel corso introduttivo alla psicoterapia (programma 2024).`,
+          creditiMissingProgram: "Devi rispondere alla domanda sul programma.",
           creditiMissingSSPP: "Devi rispondere alla partecipazione completa al congresso annuale SSPP.",
           creditiMissingSSPPNo: "Devi ancora effettuare una partecipazione completa obbligatoria al congresso annuale della SSPP.",
           supervisionTitle: "Supervisioni richieste",
@@ -801,22 +875,30 @@
         const t = translations[lang];
         if (!t) return;
 
+        ['intro2009Cog','intro2009Psy','intro2009Sis'].forEach(key => {
+          if (!t[key]) console.warn(`Missing translation for ${key} in ${lang}`);
+        });
+
         document.documentElement.lang = lang;
         document.getElementById('pageTitle').textContent = t.pageTitle;
         document.getElementById('headerTitle').textContent = t.headerTitle;
         document.getElementById('headerSubtitle').textContent = t.headerSubtitle;
         document.getElementById('disclaimer').innerHTML = t.disclaimer;
         document.getElementById('addPeriodBtn').textContent = t.addPeriod;
+        document.getElementById('addCreditSectionBtn').textContent = t.addCredits;
+        document.getElementById('addSupervisionSectionBtn').textContent = t.addSupervisions;
+        document.getElementById('pdfButton').textContent = t.downloadPdf;
+        document.getElementById('clearButton').textContent = t.clearAll;
         document.getElementById('labelGerontoPsy').textContent = t.questionGerontoPsy;
         document.getElementById('labelCambioCentro').textContent = t.questionCambioCentro;
         document.getElementById('workTitle').textContent = t.workTitle;
         document.getElementById('creditsTitle').textContent = t.creditsTitle;
         document.getElementById('supervisionTitle').textContent = t.supervisionTitle;
 
-        const gerntoPsySel = document.getElementById('gerontoPsy');
-        gerntoPsySel.options[0].textContent = t.selectPrompt;
-        gerntoPsySel.options[1].textContent = t.optSiG;
-        gerntoPsySel.options[2].textContent = t.optNoG;
+        const gerontoPsySel = document.getElementById('gerontoPsy');
+        gerontoPsySel.options[0].textContent = t.selectPrompt;
+        gerontoPsySel.options[1].textContent = t.optSiG;
+        gerontoPsySel.options[2].textContent = t.optNoG;
         
         const cambioCentroSel = document.getElementById('cambioCentro');
         cambioCentroSel.options[0].textContent = t.selectPrompt;
@@ -825,10 +907,15 @@
 
         document.getElementById('labelTeorici').textContent = t.labelTeorici;
         document.getElementById('introTitle').textContent = t.introTitle;
+        document.getElementById('introProgramLabel').textContent = t.introProgramQuestion;
+        const introSel = document.getElementById('introProgram');
+        introSel.options[0].textContent = t.selectPrompt;
+        introSel.options[1].textContent = t.optProgram2024;
+        introSel.options[2].textContent = t.optProgram2009;
         document.getElementById('labelCorso2024').textContent = t.labelCorso2024;
-        document.getElementById('labelCorsoCog').textContent = t.labelCorsoCog;
-        document.getElementById('labelCorsoPsy').textContent = t.labelCorsoPsy;
-        document.getElementById('labelCorsoSis').textContent = t.labelCorsoSis;
+        document.getElementById('labelCorsoCog').textContent = t.intro2009Cog;
+        document.getElementById('labelCorsoPsy').textContent = t.intro2009Psy;
+        document.getElementById('labelCorsoSis').textContent = t.intro2009Sis;
         document.getElementById('labelPsy').textContent = t.labelPsy;
         document.getElementById('labelCong').textContent = t.labelCong;
         document.getElementById('labelSSPP').textContent = t.labelSSPP;
@@ -870,13 +957,15 @@
           document.getElementById(id).style.display = 'none';
         });
         creditiMostrati = false;
-        ['creditiTeorici','creditiPsy','creditiCong','corso2024','corsoCog','corsoPsy','corsoSis','partecipazioneSSPP'].forEach(id => {
+        ['creditiTeorici','creditiPsy','creditiCong','creditiCorso2024','corsoCog','corsoPsy','corsoSis','introProgram','partecipazioneSSPP'].forEach(id => {
           const el = document.getElementById(id);
           if (!el) return;
           if (el.type === 'checkbox') el.checked = false;
           else if (el.tagName === 'SELECT') el.selectedIndex = 0;
           else el.value = '';
         });
+        document.getElementById('intro2024Fields').style.display = 'none';
+        document.getElementById('intro2009Fields').style.display = 'none';
         document.getElementById('addCreditSectionBtn').style.display = 'inline-block';
         checkShowCalcButton();
         updateResultsUI();
@@ -899,14 +988,14 @@
       };
 
       function isVisible(el) {
-        // True se l'elemento è visibile nel DOM
+        // Return true if the element is visible in the DOM
         return !!(el.offsetWidth || el.offsetHeight || el.getClientRects().length);
       }
 
       function checkShowCalcButton() {
         let someInput = false;
 
-        // Periodi di lavoro (basta che ci sia almeno uno inserito)
+        // Work periods (at least one must be entered)
         if (periodsData.some(p =>
           p.tipoAttivita ||
           p.categoria ||
@@ -914,7 +1003,7 @@
           (p.pensum && p.pensum !== '')
         )) someInput = true;
 
-        // Crediti: controlla SOLO sezione crediti visibile
+        // Credits: check only the visible credit section
         ['creditSectionTeorici', 'creditSectionPsy', 'creditSectionCong'].forEach(sectionId => {
           const section = document.getElementById(sectionId);
           if (section && isVisible(section)) {
@@ -929,7 +1018,7 @@
           }
         });
 
-        // Supervisioni: controlla SOLO sezione visibile
+        // Supervisions: check only the visible section
         ['supervisionSection', 'PsysupervisionSection'].forEach(sectionId => {
           const section = document.getElementById(sectionId);
           if (section && isVisible(section)) {
@@ -950,7 +1039,7 @@
             const idx = +e.target.closest('.periodo').dataset.idx;
             periodsData.splice(idx, 1);
             renderPeriods();
-            // Nascondi il box se tutti i periodi sono stati rimossi
+            // Hide the box if all periods have been removed
             const domandeBox = document.getElementById('DomcambioCentro');
             if (periodsData.length === 0) {
               domandeBox.style.display = "none";
@@ -975,30 +1064,36 @@
           div.className = 'periodo';
           div.dataset.idx = idx; 
           div.innerHTML = `
-            <button type="button" class="remove-period-btn" title="Rimuovi periodo">✖</button>
+            <button type="button" class="remove-period-btn" title="${t.removePeriod}">✖</button>
 
             <label>
               <select class="tipo-attivita">
                 <option value="" disabled ${!period.tipoAttivita ? "selected" : ""} hidden>${t.placeholderTipoAttivita}</option>
                 <option value="adult" ${period.tipoAttivita === "adult" ? "selected" : ""}>${t.tipoAdult}</option>
-                <option value="inf" ${period.tipoAttivita === "inf" ? "selected" : ""}>${t.tipoInfantile}</option>
                 <option value="som" ${period.tipoAttivita === "som" ? "selected" : ""}>${t.tipoSomatico}</option>
-                <option value="ric" ${period.tipoAttivita === "ric" ? "selected" : ""}>${t.tipoRicerca}</option>
+                <option value="inf" ${period.tipoAttivita === "inf" ? "selected" : ""}>${t.tipoInfantile}</option>
                 <option value="studio" ${period.tipoAttivita === "studio" ? "selected" : ""}>${t.tipoStudio}</option>
+                <option value="ric" ${period.tipoAttivita === "ric" ? "selected" : ""}>${t.tipoRicerca}</option>
               </select>
             </label>
-            
+
             <label class="categoria-label" style="${period.tipoAttivita === 'adult' ? '' : 'display:none'}">
               <select class="categoria-attivita">
                 <option value="" disabled ${!period.categoria ? "selected" : ""} hidden>${t.placeholderCategoria}</option>
                 <option value="ospA" ${period.categoria === "ospA" ? "selected" : ""}>${t.catAOsp}</option>
-                <option value="ambA" ${period.categoria === "ambA" ? "selected" : ""}>${t.catAAmb}</option>
                 <option value="ospB" ${period.categoria === "ospB" ? "selected" : ""}>${t.catBOsp}</option>
-                <option value="ambB" ${period.categoria === "ambB" ? "selected" : ""}>${t.catBAmb}</option>
                 <option value="ospC" ${period.categoria === "ospC" ? "selected" : ""}>${t.catCOsp}</option>
+                <option value="ambA" ${period.categoria === "ambA" ? "selected" : ""}>${t.catAAmb}</option>
+                <option value="ambB" ${period.categoria === "ambB" ? "selected" : ""}>${t.catBAmb}</option>
                 <option value="ambC" ${period.categoria === "ambC" ? "selected" : ""}>${t.catCAmb}</option>
-                <option value="studio" ${period.categoria === "studio" ? "selected" : ""}>${t.tipoStudio}</option>
-                <option value="formAppr" ${period.categoria === "formAppr" ? "selected" : ""}>${t.catFormApprof}</option>
+                <option value="gerOsp" ${period.categoria === "gerOsp" ? "selected" : ""}>${t.catGerOsp}</option>
+                <option value="gerAmb" ${period.categoria === "gerAmb" ? "selected" : ""}>${t.catGerAmb}</option>
+                <option value="dipOsp" ${period.categoria === "dipOsp" ? "selected" : ""}>${t.catDipOsp}</option>
+                <option value="dipAmb" ${period.categoria === "dipAmb" ? "selected" : ""}>${t.catDipAmb}</option>
+                <option value="forOsp" ${period.categoria === "forOsp" ? "selected" : ""}>${t.catForOsp}</option>
+                <option value="forAmb" ${period.categoria === "forAmb" ? "selected" : ""}>${t.catForAmb}</option>
+                <option value="liaOsp" ${period.categoria === "liaOsp" ? "selected" : ""}>${t.catLiaOsp}</option>
+                <option value="liaAmb" ${period.categoria === "liaAmb" ? "selected" : ""}>${t.catLiaAmb}</option>
               </select>
             </label>
             
@@ -1015,7 +1110,7 @@
             const domandeBox = document.getElementById('DomcambioCentro');
             if (periodsData.length === 0) {
               domandeBox.style.display = "none";
-              primaAggiunta = true; // così quando riaggiungi un periodo il box ricompare
+              primaAggiunta = true; // so when a period is re-added the box reappears
             }
           container.appendChild(div);
         });
@@ -1216,6 +1311,7 @@
         const cat = {
           ospA: 0, ospB: 0, ospC: 0,
           ambA: 0, ambB: 0, ambC: 0,
+          ospOther: 0, ambOther: 0,
           studio: 0, som: 0, infanzia: 0, ricerca: 0
         };
 
@@ -1235,20 +1331,27 @@
               case "ambA": cat.ambA += mesiEff; break;
               case "ambB": cat.ambB += mesiEff; break;
               case "ambC": cat.ambC += mesiEff; break;
-              case "studio": cat.studio += mesiEff; break;
+              case "gerOsp":
+              case "dipOsp":
+              case "forOsp":
+              case "liaOsp": cat.ospOther += mesiEff; break;
+              case "gerAmb":
+              case "dipAmb":
+              case "forAmb":
+              case "liaAmb": cat.ambOther += mesiEff; break;
             }
           }
         });
 
-        const ospA = Math.min(cat.ospA, 36), ospB = Math.min(cat.ospB, 24), ospC = Math.min(cat.ospC, 24);
-        const ambA = Math.min(cat.ambA, 36), ambB = Math.min(cat.ambB, 24), ambC = Math.min(cat.ambC, 24);
+        const ospA = Math.min(cat.ospA, 36), ospB = Math.min(cat.ospB, 24), ospC = Math.min(cat.ospC, 24), ospOther = cat.ospOther;
+        const ambA = Math.min(cat.ambA, 36), ambB = Math.min(cat.ambB, 24), ambC = Math.min(cat.ambC, 24), ambOther = cat.ambOther;
         const studio = cat.studio;
         const somatico = Math.min(cat.som, 12);
         const extra = cat.infanzia + cat.ricerca;
         let extraValido = Math.min(extra, 12);
 
-        const totaleOsp = cat.ospA + cat.ospB + cat.ospC;
-        const totaleAmb = cat.ambA + cat.ambB + cat.ambC + cat.studio;
+        const totaleOsp = cat.ospA + cat.ospB + cat.ospC + cat.ospOther;
+        const totaleAmb = cat.ambA + cat.ambB + cat.ambC + cat.ambOther + cat.studio;
 
         let ospedalieroValido = Math.min(totaleOsp, 36);
         let ambulatorialeValido = Math.min(totaleAmb, 36);
@@ -1268,51 +1371,56 @@
           }
         }
 
-        const totaleOspPreTaglio = ospA + ospB + ospC;
-        let ospAValido = 0, ospBValido = 0, ospCValido = 0;
+        const totaleOspPreTaglio = ospA + ospB + ospC + ospOther;
+        let ospAValido = 0, ospBValido = 0, ospCValido = 0, ospOtherValido = 0;
         if (totaleOspPreTaglio > 0) {
           const ratioOsp = ospedalieroValido / totaleOspPreTaglio;
           ospAValido = ospA * ratioOsp;
           ospBValido = ospB * ratioOsp;
           ospCValido = ospC * ratioOsp;
+          ospOtherValido = ospOther * ratioOsp;
         }
-
-        const totaleAmbPreTaglio = ambA + ambB + ambC + studio;
-        let ambAValido = 0, ambBValido = 0, ambCValido = 0, studioValido = 0;
+        const totaleAmbPreTaglio = ambA + ambB + ambC + ambOther + studio;
+        let ambAValido = 0, ambBValido = 0, ambCValido = 0, ambOtherValido = 0, studioValido = 0;
         if (totaleAmbPreTaglio > 0) {
           const ratioAmb = ambulatorialeValido / totaleAmbPreTaglio;
           ambAValido = ambA * ratioAmb;
           ambBValido = ambB * ratioAmb;
           ambCValido = ambC * ratioAmb;
+          ambOtherValido = ambOther * ratioAmb;
           studioValido = studio * ratioAmb;
         }
         const totale = somatico + ospedalieroValido + ambulatorialeValido + extraValido;
 
         const bar = x => (x / 72) * 100;
         html1 += `<div class="stacked-bar-container" style="display:flex;height:20px;width:100%;border-radius:10px;overflow:hidden;margin-bottom:12px">`;
-        if (ospAValido > 0) html1 += `<div class="stacked-bar-segment" style="width:${bar(ospAValido)}%; background:darkgreen;" title="Ospedaliero A"></div>`;
-        if (ospBValido > 0) html1 += `<div class="stacked-bar-segment" style="width:${bar(ospBValido)}%; background:#6fcf97;" title="Ospedaliero B"></div>`;
-        if (ospCValido > 0) html1 += `<div class="stacked-bar-segment" style="width:${bar(ospCValido)}%; background:#a8e6cf;" title="Ospedaliero C"></div>`;
-        if (ambAValido > 0) html1 += `<div class="stacked-bar-segment" style="width:${bar(ambAValido)}%; background:darkblue;" title="Ambulatoriale A"></div>`;
-        if (ambBValido > 0) html1 += `<div class="stacked-bar-segment" style="width:${bar(ambBValido)}%; background:#5dade2;" title="Ambulatoriale B"></div>`;
-        if (ambCValido > 0) html1 += `<div class="stacked-bar-segment" style="width:${bar(ambCValido)}%; background:#aed6f1;" title="Ambulatoriale C"></div>`;
-        if (studioValido > 0) html1 += `<div class="stacked-bar-segment" style="width:${bar(studioValido)}%; background:#d4e6f1;" title="Studio Medico"></div>`;
-        if (somatico > 0) html1 += `<div class="stacked-bar-segment" style="width:${bar(somatico)}%; background:gold;" title="Somatico"></div>`;
-        if (extraValido > 0) html1 += `<div class="stacked-bar-segment" style="width:${bar(extraValido)}%; background:violet;" title="Extra"></div>`;
-        if (totale < 72) html1 += `<div class="stacked-bar-segment" style="width:${bar(72 - totale)}%; background:#ccc;" title="Mesi mancanti"></div>`;
+        if (ospAValido > 0) html1 += `<div class="stacked-bar-segment" style="width:${bar(ospAValido)}%; background:darkgreen;" title="${t.catAOsp}"></div>`;
+        if (ospBValido > 0) html1 += `<div class="stacked-bar-segment" style="width:${bar(ospBValido)}%; background:#6fcf97;" title="${t.catBOsp}"></div>`;
+        if (ospCValido > 0) html1 += `<div class="stacked-bar-segment" style="width:${bar(ospCValido)}%; background:#a8e6cf;" title="${t.catCOsp}"></div>`;
+        if (ospOtherValido > 0) html1 += `<div class="stacked-bar-segment" style="width:${bar(ospOtherValido)}%; background:#82e0aa;" title="${t.catOtherOsp}"></div>`;
+        if (ambAValido > 0) html1 += `<div class="stacked-bar-segment" style="width:${bar(ambAValido)}%; background:darkblue;" title="${t.catAAmb}"></div>`;
+        if (ambBValido > 0) html1 += `<div class="stacked-bar-segment" style="width:${bar(ambBValido)}%; background:#5dade2;" title="${t.catBAmb}"></div>`;
+        if (ambCValido > 0) html1 += `<div class="stacked-bar-segment" style="width:${bar(ambCValido)}%; background:#aed6f1;" title="${t.catCAmb}"></div>`;
+        if (ambOtherValido > 0) html1 += `<div class="stacked-bar-segment" style="width:${bar(ambOtherValido)}%; background:#85c1e9;" title="${t.catOtherAmb}"></div>`;
+        if (studioValido > 0) html1 += `<div class="stacked-bar-segment" style="width:${bar(studioValido)}%; background:#d4e6f1;" title="${t.tipoStudio}"></div>`;
+        if (somatico > 0) html1 += `<div class="stacked-bar-segment" style="width:${bar(somatico)}%; background:gold;" title="${t.tipoSomatico}"></div>`;
+        if (extraValido > 0) html1 += `<div class="stacked-bar-segment" style="width:${bar(extraValido)}%; background:violet;" title="${t.extraLabel}"></div>`;
+        if (totale < 72) html1 += `<div class="stacked-bar-segment" style="width:${bar(72 - totale)}%; background:#ccc;" title="${t.missingMonths}"></div>`;
         html1 += `</div>`;
 
         html1 += `<div class="legenda" style="margin-bottom:16px">`;
         if (ospA > 0) html1 += `<span style="background:darkgreen;color:white;padding:2px 8px;border-radius:8px;margin-right:5px">${t.catAOsp}</span>`;
         if (ospB > 0) html1 += `<span style="background:#6fcf97;color:white;padding:2px 8px;border-radius:8px;margin-right:5px">${t.catBOsp}</span>`;
         if (ospC > 0) html1 += `<span style="background:#a8e6cf;color:white;padding:2px 8px;border-radius:8px;margin-right:5px">${t.catCOsp}</span>`;
+        if (ospOther > 0) html1 += `<span style="background:#82e0aa;color:white;padding:2px 8px;border-radius:8px;margin-right:5px">${t.catOtherOsp}</span>`;
         if (ambA > 0) html1 += `<span style="background:darkblue;color:white;padding:2px 8px;border-radius:8px;margin-right:5px">${t.catAAmb}</span>`;
         if (ambB > 0) html1 += `<span style="background:#5dade2;color:white;padding:2px 8px;border-radius:8px;margin-right:5px">${t.catBAmb}</span>`;
         if (ambC > 0) html1 += `<span style="background:#aed6f1;color:white;padding:2px 8px;border-radius:8px;margin-right:5px">${t.catCAmb}</span>`;
+        if (ambOther > 0) html1 += `<span style="background:#85c1e9;color:white;padding:2px 8px;border-radius:8px;margin-right:5px">${t.catOtherAmb}</span>`;
         if (studio > 0) html1 += `<span style="background:#d4e6f1;color:white;padding:2px 8px;border-radius:8px;margin-right:5px">${t.tipoStudio}</span>`;
         if (somatico > 0) html1 += `<span style="background:gold;color:white;padding:2px 8px;border-radius:8px;margin-right:5px">${t.tipoSomatico}</span>`;
-        if (extraValido > 0) html1 += `<span style="background:violet;color:white;padding:2px 8px;border-radius:8px;margin-right:5px">Extra</span>`;
-        if (totale < 72) html1 += `<span style="background:#ccc;color:white;padding:2px 8px;border-radius:8px;margin-right:5px">${(lang==="de" ? "Fehlende Monate" : (lang==="fr" ? "Mois manquants" : "Mesi mancanti"))}</span>`;
+        if (extraValido > 0) html1 += `<span style="background:violet;color:white;padding:2px 8px;border-radius:8px;margin-right:5px">${t.extraLabel}</span>`;
+        if (totale < 72) html1 += `<span style="background:#ccc;color:white;padding:2px 8px;border-radius:8px;margin-right:5px">${t.missingMonths}</span>`;
         html1 += `</div>`;
 
         if (ospA < 12) mancanze.push(tReplace(t.missingOspA, { n: Math.round(12 - ospA) }));
@@ -1338,7 +1446,7 @@
           mancanze.forEach(m => html1 += `<li>${m}</li>`);
           html1 += '</ul>';
         } else {
-        html1 += `<p style="color:green"><b>${lang === "it" ? "✅ Non ci sono mancanze nei periodi inseriti." : (lang === "de" ? "✅ Keine Lücken in den eingegebenen Zeiträumen." : "✅ Aucune lacune dans les périodes saisies.")}</b></p>`;
+        html1 += `<p style="color:green"><b>${t.periodsNoMissing}</b></p>`;
         }
 
         document.getElementById('risultato').innerHTML = `<div class="section">${html1}</div>`;
@@ -1367,7 +1475,22 @@
           mancanze.push(t.creditiMissingSSPPNo);
         }
 
-        const teorici = parseFloat(document.getElementById('creditiTeorici').value) || 0;
+        const teoriciBase = parseFloat(document.getElementById('creditiTeorici').value) || 0;
+        const program = document.getElementById('introProgram').value;
+        let introCrediti = 0;
+        let corsi2009 = null;
+        if (program === '2024') {
+          introCrediti = parseFloat(document.getElementById('creditiCorso2024').value) || 0;
+        } else if (program === '2009') {
+          corsi2009 = [
+            { id: 'corsoCog', label: t.intro2009Cog },
+            { id: 'corsoPsy', label: t.intro2009Psy },
+            { id: 'corsoSis', label: t.intro2009Sis }
+          ];
+          introCrediti = corsi2009.filter(c => document.getElementById(c.id).checked).length * 12;
+        }
+
+        const teorici = teoriciBase + introCrediti;
         const psy = parseFloat(document.getElementById('creditiPsy').value) || 0;
         const cong = parseFloat(document.getElementById('creditiCong').value) || 0;
         const maxTeorici = 240, maxPsy = 180, maxCong = 180;
@@ -1399,20 +1522,18 @@
         if (psy < maxPsy) mancanze.push(t.creditiMissingPsy(maxPsy - psy));
         if (cong < maxCong) mancanze.push(t.creditiMissingCong(maxCong - cong));
 
-        const fatto2024 = document.getElementById('corso2024').checked;
-        const corsi2009 = [
-          { id: 'corsoCog', label: t.labelCorsoCog },
-          { id: 'corsoPsy', label: t.labelCorsoPsy },
-          { id: 'corsoSis', label: t.labelCorsoSis }
-        ];
-    
-        const selezionati2009 = corsi2009.filter(c => document.getElementById(c.id).checked);
-
-        if (!fatto2024 && selezionati2009.length === 0) {
-          mancanze.push(t.creditiMissingIntro);
-        } else if (!fatto2024 && selezionati2009.length > 0 && selezionati2009.length < corsi2009.length) {
-          const mancanti = corsi2009.filter(c => !document.getElementById(c.id).checked).map(c => c.label);
-          mancanze.push(t.creditiMissingIntroSome(mancanti));
+        if (program === '2024') {
+          if (introCrediti < 40) mancanze.push(t.creditiMissingIntro2024(40 - introCrediti));
+        } else if (program === '2009') {
+          const selezionati2009 = corsi2009.filter(c => document.getElementById(c.id).checked);
+          if (selezionati2009.length === 0) {
+            mancanze.push(t.creditiMissingIntro);
+          } else if (selezionati2009.length < corsi2009.length) {
+            const mancanti = corsi2009.filter(c => !document.getElementById(c.id).checked).map(c => c.label);
+            mancanze.push(t.creditiMissingIntroSome(mancanti));
+          }
+        } else {
+          mancanze.push(t.creditiMissingProgram);
         }
 
     
@@ -1423,46 +1544,46 @@
           mancanze.forEach(m => html2 += `<li>${m}</li>`);
           html2 += `</ul>`;
         } else {
-          html2 += `<p style="color:green"><b>${lang === "it" ? "✅ Non ci sono mancanze nei crediti inseriti." : (lang === "de" ? "✅ Keine Lücken in den eingegebenen Credits." : "✅ Aucune lacune dans les credits saisies.")}</b></p>`;
+          html2 += `<p style="color:green"><b>${t.creditsNoMissing}</b></p>`;
         }
         output.innerHTML = `<div class="section">${html2}</div>`;
       }
 
       function calcolaSupervisioni() {
-        // Identifica entrambe le sezioni di supervisione (devono essere entrambe nascoste per azzerare)
+        // Identify both supervision sections (both must be hidden to reset)
         const sec1 = document.getElementById('supervisionSection');
         const sec2 = document.getElementById('PsysupervisionSection');
         const output = document.getElementById('supervisionOutput');
 
-        // Se entrambe le sezioni non sono visibili, svuota e stoppa
+        // If both sections are not visible, clear and return
         if (!isVisible(sec1) && !isVisible(sec2)) {
           output.innerHTML = '';
           return;
         }
 
-        // Imposta lingua e traduzioni
+        // Set language and translations
         const lang = getCurrentLang();
         const t = translations[lang];
 
-        // Header della sezione supervisioni
+        // Supervision section header
         let html3 = `<h2 class="result-box-title">${t.supervisionTitle}</h2>`;
         let mancanze = [];
 
-        // Recupera valori dagli input
+        // Retrieve values from inputs
         const ippb    = parseFloat(document.getElementById('supIPPB').value)    || 0;
         const coaching = parseFloat(document.getElementById('supWeiter').value) || 0;
         const singolo = parseFloat(document.getElementById('supSingolo').value) || 0;
         const gruppo  = parseFloat(document.getElementById('supGruppo').value)  || 0;
         const change  = document.getElementById('supChange').value;
         const hrs     = document.getElementById('supHrsChange').value;
-
-        // Se campi obbligatori sono assenti o errati, mostra avviso e stoppa
+ 
+        // If required fields are missing or invalid, show warning and return
         if (ippb < 0 || coaching < 0 || singolo < 0 || gruppo < 0 || !change || !hrs) {
           output.innerHTML = `<p class="error-message">${t.supervisionCompilaTutto}</p>`;
           return;
         }
 
-        // Definisci soglie
+        // Define thresholds
         const sogliaIPPB     = 150;
         const sogliaCoaching = 30;
         const sogliaIndiv    = 15;
@@ -1470,7 +1591,7 @@
         const totPsico       = singolo + gruppo;
         const barTot         = sogliaIPPB + sogliaCoaching + sogliaTotPsico;
 
-        // Segmenti della barra
+        // Progress bar segments
         const segm = [
           { val: Math.min(ippb, sogliaIPPB), color: '#33c57d', label: t.supervisionBar.ippb },
           { val: Math.min(coaching, sogliaCoaching), color: '#ffe066', label: t.supervisionBar.coaching },
@@ -1493,7 +1614,7 @@
         const totale = ippb + coaching + singolo + gruppo;
         html3 += `<p style="margin-bottom:8px;"><strong>${t.supervisionValid(totale)}</strong></p>`;
 
-        // Qui ora uso SOLO la variabile 'mancanze' dichiarata sopra!
+        // Use only the 'mancanze' variable declared above
         if (ippb < sogliaIPPB) mancanze.push(t.supervisionMissingIPPB(sogliaIPPB - ippb));
         if (coaching < sogliaCoaching) mancanze.push(t.supervisionMissingCoaching(sogliaCoaching - coaching));
         if (totPsico < sogliaTotPsico) mancanze.push(t.supervisionMissingTotPsico(sogliaTotPsico - totPsico));
@@ -1557,10 +1678,10 @@
 
         function validateCrediti() {
             let errore = false;
-            // Validazione solo se la sezione è visibile
+            // Validate only if the section is visible
             const section = document.getElementById('creditSectionTeorici');
             if (section && isVisible(section)) {
-                ['partecipazioneSSPP'].forEach(id => {
+                ['partecipazioneSSPP','introProgram'].forEach(id => {
                 const el = document.getElementById(id);
                 if (el && el.selectedIndex === 0) {
                     el.classList.add('errore-select');
@@ -1569,7 +1690,37 @@
                     el.classList.remove('errore-select');
                 }
                 });
+                const program = document.getElementById('introProgram').value;
+                if (program === '2024') {
+                    const intro = document.getElementById('creditiCorso2024');
+                    const val = parseInt(intro.value,10);
+                    if (!val || val < 1 || val > 50) {
+                        intro.classList.add('error');
+                        errore = true;
+                    } else {
+                        intro.classList.remove('error');
+                    }
+                } else {
+                    document.getElementById('creditiCorso2024').classList.remove('error');
+                }
             }
+            return errore;
+        }
+
+        // Check that gerontopsychiatry and center change questions are answered
+        function validateGerontoCambio() {
+            let errore = false;
+            ['gerontoPsy', 'cambioCentro'].forEach(id => {
+                const el = document.getElementById(id);
+                if (el && isVisible(el)) {
+                    if (el.selectedIndex === 0) {
+                        el.classList.add('errore-select');
+                        errore = true;
+                    } else {
+                        el.classList.remove('errore-select');
+                    }
+                }
+            });
             return errore;
         }
 
@@ -1595,22 +1746,22 @@
             let errGeronto = validateGerontoCambio();
             let errCrediti = validateCrediti();
             let errSupervisioni = validateSupervisioni();
-            return !(errPeriodi || errCrediti || errSupervisioni);
+            return !(errPeriodi || errGeronto || errCrediti || errSupervisioni);
         }
 
 
       document.getElementById('calcBtn').onclick = updateResultsUI;
       
         function updateResultsUI() {
-        calculateResult();      // Periodi
-        calcolaCrediti();       // Crediti
-        calcolaSupervisioni();  // Supervisioni
-        // Sempre valida tutto!
+        calculateResult();      // Work periods
+        calcolaCrediti();       // Credits
+        calcolaSupervisioni();  // Supervisions
+        // Always validate all sections
         const errorePeriodi = validatePeriodi();
         const erroreCrediti = validateCrediti();
         const erroreSupervisioni = validateSupervisioni();
 
-        // Mostra header e PDF solo se almeno una delle sezioni è valida e senza errori
+        // Show header and PDF only if at least one section is valid without errors
         const showHeader = (
             (!errorePeriodi && document.getElementById('risultato').innerHTML.trim() !== '') ||
             (!erroreCrediti && document.getElementById('creditiOutput').innerHTML.trim() !== '') ||
@@ -1621,6 +1772,17 @@
         }
 
       
+        document.getElementById('introProgram').addEventListener('change', e => {
+          const val = e.target.value;
+          document.getElementById('intro2024Fields').style.display = val === '2024' ? 'block' : 'none';
+          document.getElementById('intro2009Fields').style.display = val === '2009' ? 'block' : 'none';
+          if (val === '2024') {
+            ['corsoCog','corsoPsy','corsoSis'].forEach(id => document.getElementById(id).checked = false);
+          } else if (val === '2009') {
+            document.getElementById('creditiCorso2024').value = '';
+          }
+        });
+
         document.getElementById('languageSwitcher').addEventListener('change', e => {
         const lang = e.target.value;
         localStorage.setItem('selectedLanguage', lang);
@@ -1747,8 +1909,8 @@
     
     
     <div id="pdfExportBox" class="offscreen">
-      <h1 id="pdfTitle" style="text-align: center; color:#352682; font-size: 2.3em; font-weight: bold; margin-bottom: 12px; font-family: sans-serif;"></h1>
-      <h2 id="pdfSubtitle" style="text-align: center; color:#352682; font-size: 1.22em; font-weight: 500; margin-bottom: 32px; font-family: sans-serif;"></h2>
+      <h1 id="pdfTitle" style="text-align: center; color:#352682; font-size: 2.3em; font-weight: bold; margin-bottom: 12px; font-family: Montserrat,system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif;"></h1>
+      <h2 id="pdfSubtitle" style="text-align: center; color:#352682; font-size: 1.22em; font-weight: 500; margin-bottom: 32px; font-family: Montserrat,system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif;"></h2>
       <div id="pdfRisultato1" style="margin-bottom:34px"></div>
       <div id="pdfRisultato2" style="margin-bottom:28px"></div>
       <div id="pdfRisultato3" style="margin-bottom:28px"></div>


### PR DESCRIPTION
## Summary
- use Montserrat font across interface and PDF export
- add program question for introductory psychotherapy courses with dynamic 2024/2009 fields
- validate program choice and enforce minimum credits for 2024 course
- include introductory course credits in theoretical total and align 2009 course checkboxes left
- deduplicate 2009 course labels across translations to avoid overwritten text
- reorder work period type hierarchy and expand adult categories with gerontopsychiatry, dependency, forensic, and liaison options
- track non–category A hospital and ambulatory months separately in progress calculations
- refactor intro-course labels and credit logic to remove duplicate keys and fix 2009-program credit reporting

## Testing
- `npm test` *(fails: Could not read package.json: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6880d07e7a2883289942ebc643ffcd36